### PR TITLE
Implement initial Note2Markdown skeleton

### DIFF
--- a/NoteToMarkdownApp/Models/ImageHandlingOption.swift
+++ b/NoteToMarkdownApp/Models/ImageHandlingOption.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+enum ImageHandlingOption: String, CaseIterable, Codable {
+    case ignore
+    case saveLocal
+    case customSubfolder
+
+    var description: String {
+        switch self {
+        case .ignore: return "Ignore"
+        case .saveLocal: return "Save as Local Files"
+        case .customSubfolder: return "Customize subfolder"
+        }
+    }
+}

--- a/NoteToMarkdownApp/Models/MarkdownConverter.swift
+++ b/NoteToMarkdownApp/Models/MarkdownConverter.swift
@@ -1,0 +1,35 @@
+import Foundation
+import WebKit
+
+final class MarkdownConverter: NSObject {
+    private var webView: WKWebView!
+    private var completion: ((String) -> Void)?
+
+    override init() {
+        super.init()
+        let config = WKWebViewConfiguration()
+        webView = WKWebView(frame: .zero, configuration: config)
+        webView.navigationDelegate = self
+    }
+
+    func convert(html: String, completion: @escaping (String) -> Void) {
+        self.completion = completion
+        let htmlString = """
+        <html><head><script src='turndown.js'></script></head><body>\(html)</body></html>
+        """
+        webView.loadHTMLString(htmlString, baseURL: Bundle.main.resourceURL)
+    }
+}
+
+extension MarkdownConverter: WKNavigationDelegate {
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        let js = "new TurndownService().turndown(document.body.innerHTML);"
+        webView.evaluateJavaScript(js) { result, error in
+            if let markdown = result as? String {
+                self.completion?(markdown)
+            } else {
+                self.completion?("")
+            }
+        }
+    }
+}

--- a/NoteToMarkdownApp/Models/Note.swift
+++ b/NoteToMarkdownApp/Models/Note.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+struct Note: Identifiable, Codable {
+    var id: UUID = UUID()
+    var title: String
+    var markdown: String
+    var createdAt: Date = Date()
+}
+
+extension Note {
+    static var example: Note {
+        Note(title: "Example", markdown: "# Example\nThis is a sample note.")
+    }
+}

--- a/NoteToMarkdownApp/NoteToMarkdownApp.swift
+++ b/NoteToMarkdownApp/NoteToMarkdownApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct NoteToMarkdownApp: App {
+    var body: some Scene {
+        WindowGroup {
+            HomePageView()
+        }
+    }
+}

--- a/NoteToMarkdownApp/Views/HomePageView.swift
+++ b/NoteToMarkdownApp/Views/HomePageView.swift
@@ -1,0 +1,49 @@
+import SwiftUI
+
+struct HomePageView: View {
+    @State private var searchText: String = ""
+    @State private var notes: [Note] = []
+
+    var body: some View {
+        NavigationView {
+            VStack {
+                if notes.isEmpty {
+                    Spacer()
+                    Text("No notes yet. Share a note from Apple Notes or paste one.")
+                        .multilineTextAlignment(.center)
+                        .padding()
+                    Button("Paste") {
+                        // TODO: handle paste
+                    }
+                    Spacer()
+                } else {
+                    List(filteredNotes) { note in
+                        NavigationLink(destination: SinglePageView(note: note)) {
+                            Text(note.title)
+                        }
+                    }
+                    .searchable(text: $searchText)
+                }
+            }
+            .navigationTitle("Notes")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Import") {
+                        // TODO: open Apple Notes
+                    }
+                }
+            }
+        }
+    }
+
+    var filteredNotes: [Note] {
+        if searchText.isEmpty { return notes }
+        return notes.filter { $0.title.localizedCaseInsensitiveContains(searchText) }
+    }
+}
+
+struct HomePageView_Previews: PreviewProvider {
+    static var previews: some View {
+        HomePageView()
+    }
+}

--- a/NoteToMarkdownApp/Views/SettingsView.swift
+++ b/NoteToMarkdownApp/Views/SettingsView.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+struct SettingsView: View {
+    @State private var imageOption: ImageHandlingOption = .ignore
+
+    var body: some View {
+        NavigationView {
+            Form {
+                Section(header: Text("Images")) {
+                    Picker("Handling", selection: $imageOption) {
+                        ForEach(ImageHandlingOption.allCases, id: \.self) { option in
+                            Text(option.description).tag(option)
+                        }
+                    }
+                }
+                Section(header: Text("Front Matter")) {
+                    Text("Configure fields")
+                    // TODO: front matter configuration
+                }
+            }
+            .navigationTitle("Settings")
+            .navigationBarTitleDisplayMode(.inline)
+        }
+    }
+}
+
+struct SettingsView_Previews: PreviewProvider {
+    static var previews: some View {
+        SettingsView()
+    }
+}

--- a/NoteToMarkdownApp/Views/SinglePageView.swift
+++ b/NoteToMarkdownApp/Views/SinglePageView.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+
+struct SinglePageView: View {
+    var note: Note
+    @State private var showSettings = false
+
+    var body: some View {
+        VStack {
+            ScrollView {
+                Text(note.markdown)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding()
+            }
+            HStack {
+                Button(action: export) {
+                    Label("Export", systemImage: "square.and.arrow.up")
+                }
+                Spacer()
+                Button(action: copyToClipboard) {
+                    Label("Copy", systemImage: "doc.on.doc")
+                }
+            }
+            .padding()
+        }
+        .navigationTitle(note.title)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button(action: { showSettings.toggle() }) {
+                    Image(systemName: "gearshape")
+                }
+            }
+        }
+        .sheet(isPresented: $showSettings) {
+            SettingsView()
+        }
+    }
+
+    func export() {
+        // TODO: export markdown
+    }
+
+    func copyToClipboard() {
+        UIPasteboard.general.string = note.markdown
+    }
+}
+
+struct SinglePageView_Previews: PreviewProvider {
+    static var previews: some View {
+        SinglePageView(note: Note.example)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
-# note2Markdown
-convert apple notes to markdown on IOS
+# Note2Markdown
+
+This repository contains the initial skeleton for **Note2Markdown**, an iOS application that converts Apple Notes to Markdown. The project includes placeholders for the main SwiftUI app and a Share Extension.
+
+## Project Structure
+
+```
+NoteToMarkdownApp/      - Main SwiftUI application
+  ├── Views/           - SwiftUI views (HomePage, SinglePage, Settings)
+  ├── Models/          - Note model and helpers
+  └── NoteToMarkdownApp.swift
+ShareExtension/        - Share extension entry point
+Shared/                - Shared utilities (conversion, storage, image handling)
+Resources/             - JavaScript resources (Turndown)
+```
+
+The code is a starting point based on the provided specification. Core functionality such as Markdown conversion, image handling, and note persistence still need to be implemented.

--- a/Resources/turndown.js
+++ b/Resources/turndown.js
@@ -1,0 +1,5 @@
+function TurndownService() {}
+TurndownService.prototype.turndown = function(html) {
+    // Placeholder implementation
+    return html;
+};

--- a/ShareExtension/MarkdownPreviewView.swift
+++ b/ShareExtension/MarkdownPreviewView.swift
@@ -1,0 +1,13 @@
+import UIKit
+import SwiftUI
+
+struct MarkdownPreviewView: UIViewControllerRepresentable {
+    let markdown: String
+
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        let controller = UIActivityViewController(activityItems: [markdown], applicationActivities: nil)
+        return controller
+    }
+
+    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {}
+}

--- a/ShareExtension/ShareViewController.swift
+++ b/ShareExtension/ShareViewController.swift
@@ -1,0 +1,26 @@
+import UIKit
+import Social
+
+class ShareViewController: UIViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        handleInput()
+    }
+
+    private func handleInput() {
+        guard let item = extensionContext?.inputItems.first as? NSExtensionItem,
+              let provider = item.attachments?.first else {
+            return
+        }
+
+        if provider.hasItemConformingToTypeIdentifier("public.rtf") {
+            provider.loadItem(forTypeIdentifier: "public.rtf", options: nil) { data, error in
+                // TODO: convert RTF to Markdown
+            }
+        } else if provider.hasItemConformingToTypeIdentifier("public.html") {
+            provider.loadItem(forTypeIdentifier: "public.html", options: nil) { data, error in
+                // TODO: convert HTML to Markdown
+            }
+        }
+    }
+}

--- a/Shared/Conversion/RTFToHTMLConverter.swift
+++ b/Shared/Conversion/RTFToHTMLConverter.swift
@@ -1,0 +1,18 @@
+import Foundation
+import UIKit
+
+struct RTFToHTMLConverter {
+    static func convert(data: Data) -> String? {
+        guard let attributedString = try? NSAttributedString(data: data, options: [.documentType: NSAttributedString.DocumentType.rtf], documentAttributes: nil) else {
+            return nil
+        }
+        let range = NSRange(location: 0, length: attributedString.length)
+        let options: [NSAttributedString.DocumentAttributeKey: Any] = [
+            .documentType: NSAttributedString.DocumentType.html
+        ]
+        guard let htmlData = try? attributedString.data(from: range, documentAttributes: options) else {
+            return nil
+        }
+        return String(data: htmlData, encoding: .utf8)
+    }
+}

--- a/Shared/Conversion/TurndownService.swift
+++ b/Shared/Conversion/TurndownService.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+struct TurndownService {
+    static func markdown(from html: String, completion: @escaping (String) -> Void) {
+        let converter = MarkdownConverter()
+        converter.convert(html: html) { markdown in
+            completion(markdown)
+        }
+    }
+}

--- a/Shared/ImageHandling/ImageProcessor.swift
+++ b/Shared/ImageHandling/ImageProcessor.swift
@@ -1,0 +1,14 @@
+import UIKit
+
+struct ImageProcessor {
+    static func save(image: UIImage, name: String) -> URL? {
+        guard let data = image.pngData() else { return nil }
+        let url = StorageFileManager.shared.directory.appendingPathComponent(name)
+        do {
+            try data.write(to: url)
+            return url
+        } catch {
+            return nil
+        }
+    }
+}

--- a/Shared/Storage/FileManager.swift
+++ b/Shared/Storage/FileManager.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+struct StorageFileManager {
+    static let shared = StorageFileManager()
+    let directory: URL
+
+    init() {
+        let fm = FileManager.default
+        let groupId = "group.com.example.note2markdown"
+        directory = fm.containerURL(forSecurityApplicationGroupIdentifier: groupId) ?? fm.temporaryDirectory
+    }
+
+    func save(markdown: String, fileName: String) -> URL? {
+        let url = directory.appendingPathComponent(fileName)
+        do {
+            try markdown.write(to: url, atomically: true, encoding: .utf8)
+            return url
+        } catch {
+            return nil
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add SwiftUI views for Home, Single page, and Settings
- sketch main `NoteToMarkdownApp` and data models
- include share extension stubs and shared utilities
- provide placeholder Turndown script
- update README with project structure

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_684ac68f05f0832186fda206ab0d8b6a